### PR TITLE
FIX: Commas in filenames aren't processed

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -25,5 +25,6 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class AppConfig(BaseSettings):
+    commons_ip_version: str = ""
     commons_ip_path: str = ""
     model_config = SettingsConfigDict(env_file=".env")

--- a/app/routers/about.py
+++ b/app/routers/about.py
@@ -22,14 +22,28 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+from functools import lru_cache
+from typing import Annotated
+
 from eark_validator.cli.app import __version__ as version
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+
+from app import config
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
 
+@lru_cache()
+def get_settings():
+    return config.AppConfig()
+
 @router.get("/about", tags=["about"], response_class=HTMLResponse)
-async def read_home(request: Request):
-    return templates.TemplateResponse(request=request, name="about.html")
+async def read_home(request: Request, settings: Annotated[config.AppConfig, Depends(get_settings)]):
+    context = {
+        'config': {
+            'eark-validator': version,
+            'commons-ip': settings.commons_ip_version
+    }       }
+    return templates.TemplateResponse(request=request, context=context, name="about.html")

--- a/templates/home.html
+++ b/templates/home.html
@@ -8,10 +8,11 @@
       <div class="media-body">
         <h1 class="media-heading">E-ARK Information Package Validation</h1>
       </div>
+      <p class="lead">This service provides E-ARK information package validation against the E-ARK SIP specification,
+        using v{{ eark_validator }} of the eark-validator and v{{ commons_ip }} of the commons-ip validator.</p>
     </div>
-    <div class="row">
-      <div class="col"></div>
-      <div class="col-8">
+    <div class="row justify-content-center">
+      <div class="col">
         <h2>Choose an information package:</h2>
         <form id="frm-validate" action="validate" method="post" enctype="multipart/form-data" encoding="multipart/form-data">
           <div class="custom-file">
@@ -20,7 +21,6 @@
             <span id="file-desc">Upload an E-ARK information package in zip, tar, or tar.gz formats.</span>
           </div>
           <div class="form-group">
-            <label for="sha1">Package SHA-1: </label>
             <input name="sha1" type="text" class="form-control"  placeholder="SHA-1 hash of selected file." readonly >
             <span id="sha-desc">This is calculated in your browser and used to ensure the package upload is error free.</span>
           </div>
@@ -28,7 +28,6 @@
           <p id="upload-desc">Upload the information package for validation. The maximum upload size limit is currently 40MB.</p>
         </form>
       </div>
-      <div class="col"></div>
     </div><!-- end row -->
 {% endblock page_content %}
 {% block page_script %}

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -9,6 +9,9 @@
         <li class="nav-item active">
           <a class="nav-link" href="/">Validate<span class="sr-only">(current)</span></a>
         </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="/about">About<span class="sr-only">(current)</span></a>
+        </li>
       </ul>
     </div>
 </nav>

--- a/templates/result.html
+++ b/templates/result.html
@@ -12,7 +12,7 @@
   <li class="nav-item" role="presentation">
     <a class="nav-link active" id="java-tab" data-toggle="tab" href="#java" role="tab" aria-controls="java" aria-selected="true">
     {% if java_summary is defined %}
-      <h3>Commons-ip Validator: {{ validation_badge(java_summary.result) }}
+      <h3>Commons-ip v{{ commons_ip }}: {{ validation_badge(java_summary.result) }}
       {% if java_summary.errors is defined %}{{ rule_summary(java_summary.errors, "errors") }}{% endif %}
       {% if java_summary.warnings is defined %}{{ rule_summary(java_summary.warnings, "warnings") }}{% endif %}
       {% if java_summary.infos is defined %}{{ rule_summary(java_summary.infos, "notes") }}{% endif %}</h3>
@@ -24,7 +24,7 @@
   <li class="nav-item" role="presentation">
     <a class="nav-link" id="python-tab" data-toggle="tab" href="#python" role="tab" aria-controls="python" aria-selected="false">
     {% if python_summary is defined %}
-      <h3>PyIP Validator: {{ validation_badge(python_summary.result) }}
+      <h3>E-ARK v{{ eark_validator }}: {{ validation_badge(python_summary.result) }}
       {% if python_summary.errors is defined %}{{ rule_summary(python_summary.errors, "errors") }}{% endif %}
       {% if python_summary.warnings is defined %}{{ rule_summary(python_summary.warnings, "warnings") }}{% endif %}
       {% if python_summary.infos is defined %}{{ rule_summary(python_summary.infos, "notes") }}{% endif %}</h3>


### PR DESCRIPTION
- uploaded files are now saved as `<hex-sha1>.zip` to avoid issues with filenames in general (including commas);
- added eark-validator and commons-ip version details to home, results and about pages;
- added a configuration mechanism as part of the above and suitable cached methods to retrieve the details;
- prefer `pathlib` to `os` for path and file manipulation; and
- updated commons-ip to v2.8.1.